### PR TITLE
Add Bluetooth audio widget and widget visibility toggles

### DIFF
--- a/Barik/Config/ConfigModels.swift
+++ b/Barik/Config/ConfigModels.swift
@@ -273,6 +273,9 @@ struct ForegroundConfig: Decodable {
     let horizontalPadding: CGFloat
     let widgetsBackground: WidgetBackgroundConfig
     let spacing: CGFloat
+    let showClock: Bool
+    let showBattery: Bool
+    let showNetwork: Bool
 
     init() {
         self.height = .barikDefault
@@ -281,6 +284,9 @@ struct ForegroundConfig: Decodable {
         self.horizontalPadding = Constants.menuBarHorizontalPadding
         self.widgetsBackground = WidgetBackgroundConfig()
         self.spacing = 15
+        self.showClock = true
+        self.showBattery = true
+        self.showNetwork = true
     }
 
     init(from decoder: Decoder) throws {
@@ -291,6 +297,9 @@ struct ForegroundConfig: Decodable {
         horizontalPadding = try container.decodeIfPresent(CGFloat.self, forKey: .horizontalPadding) ?? Constants.menuBarHorizontalPadding
         widgetsBackground = try container.decodeIfPresent(WidgetBackgroundConfig.self, forKey: .widgetsBackground) ?? WidgetBackgroundConfig()
         spacing = try container.decodeIfPresent(CGFloat.self, forKey: .spacing) ?? 15
+        showClock = try container.decodeIfPresent(Bool.self, forKey: .showClock) ?? true
+        showBattery = try container.decodeIfPresent(Bool.self, forKey: .showBattery) ?? true
+        showNetwork = try container.decodeIfPresent(Bool.self, forKey: .showNetwork) ?? true
     }
 
     enum CodingKeys: String, CodingKey {
@@ -300,6 +309,9 @@ struct ForegroundConfig: Decodable {
         case horizontalPadding = "horizontal-padding"
         case widgetsBackground = "widgets-background"
         case spacing
+        case showClock = "show-clock"
+        case showBattery = "show-battery"
+        case showNetwork = "show-network"
     }
 
     func resolveHeight() -> CGFloat {

--- a/Barik/Views/MenuBarView.swift
+++ b/Barik/Views/MenuBarView.swift
@@ -21,13 +21,18 @@ struct MenuBarView: View {
 
         let position = configManager.config.experimental.foreground.position
         let padding = configManager.config.experimental.foreground.horizontalPadding
+        let foreground = configManager.config.experimental.foreground
 
-        // Hide system widgets when bar is at bottom (already in macOS top menu bar)
-        let systemWidgetsToHide: Set<String> = position == .bottom
-            ? ["default.network", "default.battery", "default.time"]
-            : []
+        // Build set of widgets to hide based on config flags
+        let widgetsToHide: Set<String> = {
+            var set = Set<String>()
+            if !foreground.showClock { set.insert("default.time") }
+            if !foreground.showBattery { set.insert("default.battery") }
+            if !foreground.showNetwork { set.insert("default.network") }
+            return set
+        }()
         let items = configManager.config.rootToml.widgets.displayed.filter {
-            !systemWidgetsToHide.contains($0.id)
+            !widgetsToHide.contains($0.id)
         }
 
         let alignment: Alignment = switch position {
@@ -77,6 +82,9 @@ struct MenuBarView: View {
         case "default.nowplaying":
             NowPlayingWidget()
                 .environmentObject(config)
+
+        case "default.bluetooth":
+            BluetoothWidget()
 
         case "spacer":
             Spacer().frame(minWidth: 50, maxWidth: .infinity)

--- a/Barik/Widgets/Bluetooth/BluetoothManager.swift
+++ b/Barik/Widgets/Bluetooth/BluetoothManager.swift
@@ -1,0 +1,139 @@
+import Combine
+import Foundation
+import CoreAudio
+import AudioToolbox
+
+struct BluetoothDevice {
+    let name: String
+    let deviceID: AudioDeviceID
+}
+
+class BluetoothManager: ObservableObject {
+    @Published var activeBluetoothAudio: BluetoothDevice?
+
+    private var listenerBlock: AudioObjectPropertyListenerBlock?
+
+    init() {
+        updateCurrentDevice()
+        setupAudioListener()
+    }
+
+    deinit {
+        removeAudioListener()
+    }
+
+    private func setupAudioListener() {
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: AudioObjectPropertySelector(kAudioHardwarePropertyDefaultOutputDevice),
+            mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
+            mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster)
+        )
+
+        listenerBlock = { [weak self] _, _ in
+            DispatchQueue.main.async {
+                self?.updateCurrentDevice()
+            }
+        }
+
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &propertyAddress,
+            DispatchQueue.main,
+            listenerBlock!
+        )
+    }
+
+    private func removeAudioListener() {
+        guard let block = listenerBlock else { return }
+
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: AudioObjectPropertySelector(kAudioHardwarePropertyDefaultOutputDevice),
+            mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
+            mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster)
+        )
+
+        AudioObjectRemovePropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &propertyAddress,
+            DispatchQueue.main,
+            block
+        )
+    }
+
+    func updateCurrentDevice() {
+        let deviceID = getDefaultOutputDevice()
+
+        guard deviceID != kAudioDeviceUnknown else {
+            activeBluetoothAudio = nil
+            return
+        }
+
+        let name = getDeviceName(deviceID: deviceID)
+        let transportType = getDeviceTransportType(deviceID: deviceID)
+        let isBluetooth = transportType == kAudioDeviceTransportTypeBluetooth ||
+                          transportType == kAudioDeviceTransportTypeBluetoothLE
+
+        if isBluetooth {
+            activeBluetoothAudio = BluetoothDevice(name: name, deviceID: deviceID)
+        } else {
+            activeBluetoothAudio = nil
+        }
+    }
+
+    private func getDefaultOutputDevice() -> AudioDeviceID {
+        var propertySize = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var deviceID = kAudioDeviceUnknown
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: AudioObjectPropertySelector(kAudioHardwarePropertyDefaultOutputDevice),
+            mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
+            mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster)
+        )
+        AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &propertyAddress,
+            0,
+            nil,
+            &propertySize,
+            &deviceID
+        )
+        return deviceID
+    }
+
+    private func getDeviceTransportType(deviceID: AudioDeviceID) -> UInt32 {
+        var transportType: UInt32 = 0
+        var propertySize = UInt32(MemoryLayout<UInt32>.size)
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: AudioObjectPropertySelector(kAudioDevicePropertyTransportType),
+            mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
+            mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster)
+        )
+        AudioObjectGetPropertyData(
+            deviceID,
+            &propertyAddress,
+            0,
+            nil,
+            &propertySize,
+            &transportType
+        )
+        return transportType
+    }
+
+    private func getDeviceName(deviceID: AudioDeviceID) -> String {
+        var propertySize = UInt32(MemoryLayout<CFString>.size)
+        var propertyAddress = AudioObjectPropertyAddress(
+            mSelector: AudioObjectPropertySelector(kAudioDevicePropertyDeviceNameCFString),
+            mScope: AudioObjectPropertyScope(kAudioObjectPropertyScopeGlobal),
+            mElement: AudioObjectPropertyElement(kAudioObjectPropertyElementMaster)
+        )
+        var result: CFString = "" as CFString
+        AudioObjectGetPropertyData(
+            deviceID,
+            &propertyAddress,
+            0,
+            nil,
+            &propertySize,
+            &result
+        )
+        return result as String
+    }
+}

--- a/Barik/Widgets/Bluetooth/BluetoothPopup.swift
+++ b/Barik/Widgets/Bluetooth/BluetoothPopup.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct BluetoothPopup: View {
+    let device: BluetoothDevice
+
+    var body: some View {
+        VStack(spacing: 16) {
+            // Device icon
+            Image(systemName: "headphones")
+                .font(.system(size: 32))
+                .foregroundStyle(.white)
+
+            // Device name
+            Text(device.name)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+
+            // Connection status
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(.green)
+                    .frame(width: 6, height: 6)
+                Text("Connected")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            Button(action: openSoundSettings) {
+                Text("Sound Settings...")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.blue)
+        }
+        .padding(20)
+        .frame(minWidth: 160)
+    }
+
+    private func openSoundSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.Sound-Settings.extension") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+struct BluetoothPopup_Previews: PreviewProvider {
+    static var previews: some View {
+        BluetoothPopup(device: BluetoothDevice(name: "AirPods Pro", deviceID: 0))
+            .background(Color.black)
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Barik/Widgets/Bluetooth/BluetoothWidget.swift
+++ b/Barik/Widgets/Bluetooth/BluetoothWidget.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct BluetoothWidget: View {
+    @StateObject private var bluetoothManager = BluetoothManager()
+    @State private var rect: CGRect = CGRect()
+
+    var body: some View {
+        Group {
+            if let device = bluetoothManager.activeBluetoothAudio {
+                HStack(spacing: 4) {
+                    Image(systemName: "headphones")
+                        .font(.system(size: 12))
+
+                    Text(device.name)
+                        .font(.system(size: 11, weight: .medium))
+                        .lineLimit(1)
+                }
+                .foregroundStyle(.foregroundOutside)
+                .experimentalConfiguration(cornerRadius: 15)
+                .frame(maxHeight: .infinity)
+                .background(.black.opacity(0.001))
+                .background(
+                    GeometryReader { geometry in
+                        Color.clear
+                            .onAppear {
+                                rect = geometry.frame(in: .global)
+                            }
+                            .onChange(of: geometry.frame(in: .global)) { _, newState in
+                                rect = newState
+                            }
+                    }
+                )
+                .onTapGesture {
+                    MenuBarPopup.show(rect: rect, id: "bluetooth") {
+                        BluetoothPopup(device: device)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct BluetoothWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            BluetoothWidget()
+        }
+        .frame(width: 200, height: 100)
+        .background(.yellow)
+    }
+}

--- a/Barik/Widgets/Settings/SettingsPopup.swift
+++ b/Barik/Widgets/Settings/SettingsPopup.swift
@@ -21,7 +21,7 @@ struct SettingsPopup: View {
 
             // Tab content
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 20) {
                     switch selectedTab {
                     case 0: GeneralTab(configManager: configManager)
                     case 1: BarTab(configManager: configManager)
@@ -73,7 +73,7 @@ struct GeneralTab: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 20) {
             SettingsSection(title: "Appearance") {
                 HStack {
                     Text("Theme")
@@ -100,6 +100,18 @@ struct GeneralTab: View {
                     .frame(width: 120)
                 }
             }
+
+            if position == .bottom {
+                SettingsSection(title: "Duplicate Widgets") {
+                    Text("Hide widgets already shown in macOS menu bar")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Toggle("Show clock", isOn: showClockBinding)
+                    Toggle("Show battery", isOn: showBatteryBinding)
+                    Toggle("Show network", isOn: showNetworkBinding)
+                }
+            }
         }
     }
 
@@ -114,6 +126,39 @@ struct GeneralTab: View {
         Binding(
             get: { position.rawValue },
             set: { ConfigManager.shared.updateConfigValue(key: "experimental.foreground.position", newValue: $0) }
+        )
+    }
+
+    private var showClock: Bool {
+        configManager.config.experimental.foreground.showClock
+    }
+
+    private var showBattery: Bool {
+        configManager.config.experimental.foreground.showBattery
+    }
+
+    private var showNetwork: Bool {
+        configManager.config.experimental.foreground.showNetwork
+    }
+
+    private var showClockBinding: Binding<Bool> {
+        Binding(
+            get: { showClock },
+            set: { ConfigManager.shared.updateConfigValue(key: "experimental.foreground.show-clock", newValue: $0) }
+        )
+    }
+
+    private var showBatteryBinding: Binding<Bool> {
+        Binding(
+            get: { showBattery },
+            set: { ConfigManager.shared.updateConfigValue(key: "experimental.foreground.show-battery", newValue: $0) }
+        )
+    }
+
+    private var showNetworkBinding: Binding<Bool> {
+        Binding(
+            get: { showNetwork },
+            set: { ConfigManager.shared.updateConfigValue(key: "experimental.foreground.show-network", newValue: $0) }
         )
     }
 }
@@ -153,7 +198,7 @@ struct BarTab: View {
     @State private var paddingValue: Double = 25
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 20) {
             SettingsSection(title: "Background Panel") {
                 Toggle(isOn: backgroundBinding) {
                     Text("Show background panel")
@@ -269,7 +314,7 @@ struct WidgetsTab: View {
     @State private var showWindowTitle = true
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 20) {
             SettingsSection(title: "Battery") {
                 Toggle("Show percentage", isOn: $showPercentage)
                     .onChange(of: showPercentage) { _, newValue in
@@ -372,6 +417,7 @@ struct WidgetsTab: View {
                         )
                     }
             }
+
         }
         .onAppear { loadFromConfig() }
     }
@@ -420,6 +466,7 @@ struct WidgetsTab: View {
                 showWindowTitle = showTitle
             }
         }
+
     }
 }
 
@@ -476,7 +523,7 @@ struct AdvancedTab: View {
     @State private var yabaiPath: String = ""
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 20) {
             SettingsSection(title: "Tiling Window Managers") {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("AeroSpace path")
@@ -565,18 +612,18 @@ struct SettingsSection<Content: View>: View {
     @ViewBuilder let content: () -> Content
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             Text(title)
-                .font(.headline)
+                .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(.primary)
 
-            VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 12) {
                 content()
             }
-            .padding(12)
+            .padding(14)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.primary.opacity(0.05))
-            .cornerRadius(8)
+            .background(Color.primary.opacity(0.04))
+            .cornerRadius(10)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add Bluetooth widget that displays the current audio output device name when using Bluetooth audio
- Add show/hide toggles for clock, battery, and network widgets (visible when bar position is bottom)
- Improve Settings UI typography

## Changes

### Bluetooth Widget
- Uses CoreAudio to detect the default output device and check if it's Bluetooth
- Shows device name (e.g., "QCY MeloBuds Neo") with headphones icon
- Auto-hides when not using Bluetooth audio output
- Click to open popup with device info and Sound Settings link

### Config Migration  
- Automatically adds `default.bluetooth` to existing user configs that don't have it
- Inserts after `spacer` in the displayed widgets array

### Widget Visibility Toggles
- When bar position is "bottom", Settings > General shows toggles to hide clock/battery/network
- Useful since macOS already shows these in the top menu bar

### Settings UI
- Increased section spacing (16px → 20px)
- Better typography hierarchy